### PR TITLE
Correct "<" operator overload for float, int types

### DIFF
--- a/src/datatypes/FloatObject.hpp
+++ b/src/datatypes/FloatObject.hpp
@@ -99,7 +99,7 @@ public:
 
     IntObject operator<(const FloatObject &other) const
     {
-        return IntObject(value <= other.value);
+        return IntObject(value < other.value);
     }
 
     double value;

--- a/src/datatypes/IntObject.hpp
+++ b/src/datatypes/IntObject.hpp
@@ -122,7 +122,7 @@ public:
 
     IntObject operator<(const IntObject &other) const
     {
-        return IntObject(value <= other.value);
+        return IntObject(value < other.value);
     }
 
     IntObject operator%(const IntObject &other) const


### PR DESCRIPTION
"<" operator overload was mistakenly using "<="